### PR TITLE
add declaredValues constant and utility methods isDeclaredValue and isNotDeclaredValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Generate enums as relaxed type-safe enum classes supporting unknown values.
 This allows backward compatibility when JSON schemas get new enum values 
 whereas existing code does not yet know them.
 
-Enum classes have methods to detect values not yet known to an application.
+Public constant `declaredValues` allows to iterate on values known at compile time.
+Instance method `isNotDeclaredValue` allows to detect values not yet known at compile time to an application.
 
 The generated code looks like:
 
@@ -12,6 +13,7 @@ The generated code looks like:
 package org.swisspush.jsonschema2pojo.openenum;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -28,7 +30,7 @@ public class Status {
      * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.
      *
      */
-    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));
+    public final static Set<Status> declaredValues = Collections.unmodifiableSet(new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED)));
     private String value;
 
     private Status(String value) {
@@ -48,19 +50,11 @@ public class Status {
     }
 
     /**
-     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
      *
      */
-    public static Boolean isDeclaredValue(Status val) {
-        return Status.declaredValues.contains(val);
-    }
-
-    /**
-     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
-     *
-     */
-    public static Boolean isNotDeclaredValue(Status val) {
-        return (!Status.isDeclaredValue(val));
+    public Boolean isNotDeclaredValue() {
+        return (!Status.declaredValues.contains(this));
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This allows backward compatibility when JSON schemas get new enum values
 whereas existing code does not yet know them.
 
 Public constant `declaredValues` allows to iterate on values known at compile time.
-Instance method `isNotDeclaredValue` allows to detect values not yet known at compile time to an application.
+Instance method `isDeclaredValue` allows to detect values not yet known at compile time to an application.
 
 The generated code looks like:
 
@@ -50,11 +50,11 @@ public class Status {
     }
 
     /**
-     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
      *
      */
-    public Boolean isNotDeclaredValue() {
-        return (!Status.declaredValues.contains(this));
+    public Boolean isDeclaredValue() {
+        return Status.declaredValues.contains(this);
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generate enums as relaxed type-safe enum classes supporting unknown values.
 This allows backward compatibility when JSON schemas get new enum values 
 whereas existing code does not yet know them.
 
-Methods are in place to detect values not yet known to an application.
+Enum classes have methods to detect values not yet known to an application.
 
 The generated code looks like:
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Generate enums as relaxed type-safe enum classes supporting unknown values.
 This allows backward compatibility when JSON schemas get new enum values 
 whereas existing code does not yet know them.
 
+Methods are in place to detect values not yet known to an application.
+
 The generated code looks like:
 
 ```java
 package org.swisspush.jsonschema2pojo.openenum;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -19,6 +24,11 @@ public class Status {
     private final static Map<String, Status> values = new HashMap<String, Status>();
     public final static Status OPEN = Status.fromString("OPEN");
     public final static Status CLOSED = Status.fromString("CLOSED");
+    /**
+     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.
+     *
+     */
+    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));
     private String value;
 
     private Status(String value) {
@@ -35,6 +45,22 @@ public class Status {
     @JsonValue
     public String toString() {
         return this.value;
+    }
+
+    /**
+     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     *
+     */
+    public static Boolean isDeclaredValue(Status val) {
+        return Status.declaredValues.contains(val);
+    }
+
+    /**
+     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     *
+     */
+    public static Boolean isNotDeclaredValue(Status val) {
+        return (!Status.isDeclaredValue(val));
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ public class Status {
      * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
      *
      */
-    public Boolean isDeclaredValue() {
+    public boolean isDeclaredValue() {
         return Status.declaredValues.contains(this);
     }
 

--- a/src/main/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRule.java
+++ b/src/main/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRule.java
@@ -58,7 +58,7 @@ public class OpenEnumRule implements Rule<JClassContainer, JType> {
         addConstantDeclaredValues(_enum, enumConstants);
         JFieldVar valueField = addValueField(_enum, backingType);
         addToString(_enum, valueField);
-        addMethodIsNotDeclaredValue(_enum);
+        addMethodIsDeclaredValue(_enum);
         return _enum;
     }
 
@@ -201,12 +201,12 @@ public class OpenEnumRule implements Rule<JClassContainer, JType> {
         field.javadoc().add(" Use it in your application to iterate over declared values.");
     }
 
-    private void addMethodIsNotDeclaredValue(JDefinedClass _enum) {
-        JMethod method = _enum.method(JMod.PUBLIC, Boolean.class, "isNotDeclaredValue");
-        JExpression toReturn = JOp.not(_enum.staticRef("declaredValues").invoke("contains").arg(JExpr._this()));
+    private void addMethodIsDeclaredValue(JDefinedClass _enum) {
+        JMethod method = _enum.method(JMod.PUBLIC, Boolean.class, "isDeclaredValue");
+        JExpression toReturn = _enum.staticRef("declaredValues").invoke("contains").arg(JExpr._this());
         method.body()._return(toReturn);
 
-        method.javadoc().add("returns true if this enum is NOT part of the declared values.");
+        method.javadoc().add("returns true if this enum is part of the declared values.");
         method.javadoc().add(" Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.");
     }
 

--- a/src/main/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRule.java
+++ b/src/main/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRule.java
@@ -202,7 +202,7 @@ public class OpenEnumRule implements Rule<JClassContainer, JType> {
     }
 
     private void addMethodIsDeclaredValue(JDefinedClass _enum) {
-        JMethod method = _enum.method(JMod.PUBLIC, Boolean.class, "isDeclaredValue");
+        JMethod method = _enum.method(JMod.PUBLIC, boolean.class, "isDeclaredValue");
         JExpression toReturn = _enum.staticRef("declaredValues").invoke("contains").arg(JExpr._this());
         method.body()._return(toReturn);
 

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
@@ -80,11 +80,11 @@ public class OpenEnumRuleTest {
                 "    }\n" +
                 "\n" +
                 "    /**\n" +
-                "     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public Boolean isNotDeclaredValue() {\n" +
-                "        return (!Status.declaredValues.contains(this));\n" +
+                "    public Boolean isDeclaredValue() {\n" +
+                "        return Status.declaredValues.contains(this);\n" +
                 "    }\n" +
                 "\n" +
                 "}" +
@@ -153,11 +153,11 @@ public class OpenEnumRuleTest {
                 "    }\n" +
                 "\n" +
                 "    /**\n" +
-                "     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public Boolean isNotDeclaredValue() {\n" +
-                "        return (!Status.declaredValues.contains(this));\n" +
+                "    public Boolean isDeclaredValue() {\n" +
+                "        return Status.declaredValues.contains(this);\n" +
                 "    }\n" +
                 "\n" +
                 "}" +

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
@@ -83,7 +83,7 @@ public class OpenEnumRuleTest {
                 "     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public Boolean isDeclaredValue() {\n" +
+                "    public boolean isDeclaredValue() {\n" +
                 "        return Status.declaredValues.contains(this);\n" +
                 "    }\n" +
                 "\n" +
@@ -156,7 +156,7 @@ public class OpenEnumRuleTest {
                 "     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public Boolean isDeclaredValue() {\n" +
+                "    public boolean isDeclaredValue() {\n" +
                 "        return Status.declaredValues.contains(this);\n" +
                 "    }\n" +
                 "\n" +

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
@@ -42,8 +42,11 @@ public class OpenEnumRuleTest {
                 "\n" +
                 "package org.swisspush.jsonschema2pojo.openenum;\n" +
                 "\n" +
+                "import java.util.Arrays;\n" +
                 "import java.util.HashMap;\n" +
+                "import java.util.HashSet;\n" +
                 "import java.util.Map;\n" +
+                "import java.util.Set;\n" +
                 "import com.fasterxml.jackson.annotation.JsonCreator;\n" +
                 "import com.fasterxml.jackson.annotation.JsonValue;\n" +
                 "\n" +
@@ -52,6 +55,11 @@ public class OpenEnumRuleTest {
                 "    private final static Map<String, Status> values = new HashMap<String, Status>();\n" +
                 "    public final static Status OPEN = Status.fromString(\"OPEN\");\n" +
                 "    public final static Status CLOSED = Status.fromString(\"CLOSED\");\n" +
+                "    /**\n" +
+                "     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));\n" +
                 "    private String value;\n" +
                 "\n" +
                 "    private Status(String value) {\n" +
@@ -68,6 +76,22 @@ public class OpenEnumRuleTest {
                 "    @JsonValue\n" +
                 "    public String toString() {\n" +
                 "        return this.value;\n" +
+                "    }\n" +
+                "\n" +
+                "    /**\n" +
+                "     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public static Boolean isDeclaredValue(Status val) {\n" +
+                "        return Status.declaredValues.contains(val);\n" +
+                "    }\n" +
+                "\n" +
+                "    /**\n" +
+                "     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public static Boolean isNotDeclaredValue(Status val) {\n" +
+                "        return (!Status.isDeclaredValue(val));\n" +
                 "    }\n" +
                 "\n" +
                 "}" +
@@ -98,8 +122,11 @@ public class OpenEnumRuleTest {
                 "\n" +
                 "package org.swisspush.jsonschema2pojo.openenum;\n" +
                 "\n" +
+                "import java.util.Arrays;\n" +
                 "import java.util.HashMap;\n" +
+                "import java.util.HashSet;\n" +
                 "import java.util.Map;\n" +
+                "import java.util.Set;\n" +
                 "import com.fasterxml.jackson.annotation.JsonCreator;\n" +
                 "import com.fasterxml.jackson.annotation.JsonValue;\n" +
                 "\n" +
@@ -108,6 +135,11 @@ public class OpenEnumRuleTest {
                 "    private final static Map<String, Status> values = new HashMap<String, Status>();\n" +
                 "    public final static Status OPEN = Status.fromString(\"open\");\n" +
                 "    public final static Status CLOSED = Status.fromString(\"closed\");\n" +
+                "    /**\n" +
+                "     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));\n" +
                 "    private String value;\n" +
                 "\n" +
                 "    private Status(String value) {\n" +
@@ -124,6 +156,22 @@ public class OpenEnumRuleTest {
                 "    @JsonValue\n" +
                 "    public String toString() {\n" +
                 "        return this.value;\n" +
+                "    }\n" +
+                "\n" +
+                "    /**\n" +
+                "     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public static Boolean isDeclaredValue(Status val) {\n" +
+                "        return Status.declaredValues.contains(val);\n" +
+                "    }\n" +
+                "\n" +
+                "    /**\n" +
+                "     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * \n" +
+                "     */\n" +
+                "    public static Boolean isNotDeclaredValue(Status val) {\n" +
+                "        return (!Status.isDeclaredValue(val));\n" +
                 "    }\n" +
                 "\n" +
                 "}" +

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/OpenEnumRuleTest.java
@@ -43,6 +43,7 @@ public class OpenEnumRuleTest {
                 "package org.swisspush.jsonschema2pojo.openenum;\n" +
                 "\n" +
                 "import java.util.Arrays;\n" +
+                "import java.util.Collections;\n" +
                 "import java.util.HashMap;\n" +
                 "import java.util.HashSet;\n" +
                 "import java.util.Map;\n" +
@@ -56,10 +57,10 @@ public class OpenEnumRuleTest {
                 "    public final static Status OPEN = Status.fromString(\"OPEN\");\n" +
                 "    public final static Status CLOSED = Status.fromString(\"CLOSED\");\n" +
                 "    /**\n" +
-                "     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.\n" +
+                "     * Set containing all enum values declared at compile time. Use it in your application to iterate over declared values.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));\n" +
+                "    public final static Set<Status> declaredValues = Collections.unmodifiableSet(new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED)));\n" +
                 "    private String value;\n" +
                 "\n" +
                 "    private Status(String value) {\n" +
@@ -79,19 +80,11 @@ public class OpenEnumRuleTest {
                 "    }\n" +
                 "\n" +
                 "    /**\n" +
-                "     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public static Boolean isDeclaredValue(Status val) {\n" +
-                "        return Status.declaredValues.contains(val);\n" +
-                "    }\n" +
-                "\n" +
-                "    /**\n" +
-                "     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
-                "     * \n" +
-                "     */\n" +
-                "    public static Boolean isNotDeclaredValue(Status val) {\n" +
-                "        return (!Status.isDeclaredValue(val));\n" +
+                "    public Boolean isNotDeclaredValue() {\n" +
+                "        return (!Status.declaredValues.contains(this));\n" +
                 "    }\n" +
                 "\n" +
                 "}" +
@@ -123,6 +116,7 @@ public class OpenEnumRuleTest {
                 "package org.swisspush.jsonschema2pojo.openenum;\n" +
                 "\n" +
                 "import java.util.Arrays;\n" +
+                "import java.util.Collections;\n" +
                 "import java.util.HashMap;\n" +
                 "import java.util.HashSet;\n" +
                 "import java.util.Map;\n" +
@@ -136,10 +130,10 @@ public class OpenEnumRuleTest {
                 "    public final static Status OPEN = Status.fromString(\"open\");\n" +
                 "    public final static Status CLOSED = Status.fromString(\"closed\");\n" +
                 "    /**\n" +
-                "     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.\n" +
+                "     * Set containing all enum values declared at compile time. Use it in your application to iterate over declared values.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));\n" +
+                "    public final static Set<Status> declaredValues = Collections.unmodifiableSet(new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED)));\n" +
                 "    private String value;\n" +
                 "\n" +
                 "    private Status(String value) {\n" +
@@ -159,19 +153,11 @@ public class OpenEnumRuleTest {
                 "    }\n" +
                 "\n" +
                 "    /**\n" +
-                "     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
+                "     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
                 "     * \n" +
                 "     */\n" +
-                "    public static Boolean isDeclaredValue(Status val) {\n" +
-                "        return Status.declaredValues.contains(val);\n" +
-                "    }\n" +
-                "\n" +
-                "    /**\n" +
-                "     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.\n" +
-                "     * \n" +
-                "     */\n" +
-                "    public static Boolean isNotDeclaredValue(Status val) {\n" +
-                "        return (!Status.isDeclaredValue(val));\n" +
+                "    public Boolean isNotDeclaredValue() {\n" +
+                "        return (!Status.declaredValues.contains(this));\n" +
                 "    }\n" +
                 "\n" +
                 "}" +

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
@@ -1,7 +1,7 @@
 package org.swisspush.jsonschema2pojo.openenum;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -10,6 +10,11 @@ public class Status {
     private final static Map<String, Status> values = new HashMap<String, Status>();
     public final static Status OPEN = Status.fromString("OPEN");
     public final static Status CLOSED = Status.fromString("CLOSED");
+    /**
+     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.
+     *
+     */
+    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));
     private String value;
 
     private Status(String value) {
@@ -28,4 +33,19 @@ public class Status {
         return this.value;
     }
 
+    /**
+     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     *
+     */
+    public static Boolean isDeclaredValue(Status val) {
+        return Status.declaredValues.contains(val);
+    }
+
+    /**
+     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     *
+     */
+    public static Boolean isNotDeclaredValue(Status val) {
+        return !isDeclaredValue(val);
+    }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
@@ -11,10 +11,10 @@ public class Status {
     public final static Status OPEN = Status.fromString("OPEN");
     public final static Status CLOSED = Status.fromString("CLOSED");
     /**
-     * Set containing all enum values declared at compile time.use it in your application to iterate over declared values.
+     * Set containing all enum values declared at compile time. Use it in your application to iterate over declared values.
      *
      */
-    public final static Set<Status> declaredValues = new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED));
+    public final static Set<Status> declaredValues = Collections.unmodifiableSet(new HashSet<Status>(Arrays.asList(Status.OPEN, Status.CLOSED)));
     private String value;
 
     private Status(String value) {
@@ -34,18 +34,10 @@ public class Status {
     }
 
     /**
-     * returns true if given enum is part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
      *
      */
-    public static Boolean isDeclaredValue(Status val) {
-        return Status.declaredValues.contains(val);
-    }
-
-    /**
-     * returns true if given enum is NOT part of the declared values.use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
-     *
-     */
-    public static Boolean isNotDeclaredValue(Status val) {
-        return !isDeclaredValue(val);
+    public Boolean isNotDeclaredValue() {
+        return (!Status.declaredValues.contains(this));
     }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/Status.java
@@ -34,10 +34,10 @@ public class Status {
     }
 
     /**
-     * returns true if this enum is NOT part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
+     * returns true if this enum is part of the declared values. Use it in your application to detect when values coming from outside of the app are not yet part of the declared values (i.e.: there is a new version of the enum that your application is not yet aware of.
      *
      */
-    public Boolean isNotDeclaredValue() {
-        return (!Status.declaredValues.contains(this));
+    public Boolean isDeclaredValue() {
+        return Status.declaredValues.contains(this);
     }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
@@ -12,4 +12,24 @@ public class StatusTest {
         assertNotSame(Status.CLOSED, Status.fromString("OTHER"));
         assertEquals(Status.OPEN.toString(), "OPEN");
     }
+
+    @Test
+    public void isDeclaredValue() {
+        assertTrue(Status.isDeclaredValue(Status.OPEN));
+        assertTrue(Status.isDeclaredValue(Status.CLOSED));
+        assertTrue(Status.isDeclaredValue(Status.fromString("OPEN")));
+        assertTrue(Status.isDeclaredValue(Status.fromString("CLOSED")));
+        assertFalse(Status.isDeclaredValue(Status.fromString("NOT_DECLARED_VALUE")));
+        assertFalse(Status.isDeclaredValue(Status.fromString("OTHER")));
+    }
+
+    @Test
+    public void isNotDeclaredValue() {
+        assertFalse(Status.isNotDeclaredValue(Status.OPEN));
+        assertFalse(Status.isNotDeclaredValue(Status.CLOSED));
+        assertFalse(Status.isNotDeclaredValue(Status.fromString("OPEN")));
+        assertFalse(Status.isNotDeclaredValue(Status.fromString("CLOSED")));
+        assertTrue(Status.isNotDeclaredValue(Status.fromString("NOT_DECLARED_VALUE")));
+        assertTrue(Status.isNotDeclaredValue(Status.fromString("OTHER")));
+    }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
@@ -11,8 +11,6 @@ public class StatusTest {
         assertNotSame(Status.CLOSED, Status.OPEN);
         assertNotSame(Status.CLOSED, Status.fromString("OTHER"));
         assertEquals(Status.OPEN.toString(), "OPEN");
-        Status s = Status.fromString(null);
-        System.out.println(s);
     }
 
     @Test

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
@@ -11,16 +11,8 @@ public class StatusTest {
         assertNotSame(Status.CLOSED, Status.OPEN);
         assertNotSame(Status.CLOSED, Status.fromString("OTHER"));
         assertEquals(Status.OPEN.toString(), "OPEN");
-    }
-
-    @Test
-    public void isDeclaredValue() {
-        assertTrue(Status.isDeclaredValue(Status.OPEN));
-        assertTrue(Status.isDeclaredValue(Status.CLOSED));
-        assertTrue(Status.isDeclaredValue(Status.fromString("OPEN")));
-        assertTrue(Status.isDeclaredValue(Status.fromString("CLOSED")));
-        assertFalse(Status.isDeclaredValue(Status.fromString("NOT_DECLARED_VALUE")));
-        assertFalse(Status.isDeclaredValue(Status.fromString("OTHER")));
+        Status s = Status.fromString(null);
+        System.out.println(s);
     }
 
     @Test
@@ -30,6 +22,11 @@ public class StatusTest {
         assertEquals(2, Status.declaredValues.size());
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void declaredValuesIsNotModifiable() {
+        Status.declaredValues.add(Status.fromString("UNKNOWN"));
+    }
+
     @Test
     public void iterateDeclaredValues() {
         Status.declaredValues.forEach(System.out::println);
@@ -37,11 +34,11 @@ public class StatusTest {
 
     @Test
     public void isNotDeclaredValue() {
-        assertFalse(Status.isNotDeclaredValue(Status.OPEN));
-        assertFalse(Status.isNotDeclaredValue(Status.CLOSED));
-        assertFalse(Status.isNotDeclaredValue(Status.fromString("OPEN")));
-        assertFalse(Status.isNotDeclaredValue(Status.fromString("CLOSED")));
-        assertTrue(Status.isNotDeclaredValue(Status.fromString("NOT_DECLARED_VALUE")));
-        assertTrue(Status.isNotDeclaredValue(Status.fromString("OTHER")));
+        assertFalse(Status.OPEN.isNotDeclaredValue());
+        assertFalse(Status.CLOSED.isNotDeclaredValue());
+        assertFalse(Status.fromString("OPEN").isNotDeclaredValue());
+        assertFalse(Status.fromString("CLOSED").isNotDeclaredValue());
+        assertTrue(Status.fromString("NOT_DECLARED_VALUE").isNotDeclaredValue());
+        assertTrue(Status.fromString("OTHER").isNotDeclaredValue());
     }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
@@ -33,12 +33,12 @@ public class StatusTest {
     }
 
     @Test
-    public void isNotDeclaredValue() {
-        assertFalse(Status.OPEN.isNotDeclaredValue());
-        assertFalse(Status.CLOSED.isNotDeclaredValue());
-        assertFalse(Status.fromString("OPEN").isNotDeclaredValue());
-        assertFalse(Status.fromString("CLOSED").isNotDeclaredValue());
-        assertTrue(Status.fromString("NOT_DECLARED_VALUE").isNotDeclaredValue());
-        assertTrue(Status.fromString("OTHER").isNotDeclaredValue());
+    public void isDeclaredValue() {
+        assertTrue(Status.OPEN.isDeclaredValue());
+        assertTrue(Status.CLOSED.isDeclaredValue());
+        assertTrue(Status.fromString("OPEN").isDeclaredValue());
+        assertTrue(Status.fromString("CLOSED").isDeclaredValue());
+        assertFalse(Status.fromString("NOT_DECLARED_VALUE").isDeclaredValue());
+        assertFalse(Status.fromString("OTHER").isDeclaredValue());
     }
 }

--- a/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
+++ b/src/test/java/org/swisspush/jsonschema2pojo/openenum/StatusTest.java
@@ -24,6 +24,18 @@ public class StatusTest {
     }
 
     @Test
+    public void declaredValuesIsNotAffectedByFromStringCalls() {
+        assertEquals(2, Status.declaredValues.size());
+        Status.fromString("OTHER");
+        assertEquals(2, Status.declaredValues.size());
+    }
+
+    @Test
+    public void iterateDeclaredValues() {
+        Status.declaredValues.forEach(System.out::println);
+    }
+
+    @Test
     public void isNotDeclaredValue() {
         assertFalse(Status.isNotDeclaredValue(Status.OPEN));
         assertFalse(Status.isNotDeclaredValue(Status.CLOSED));


### PR DESCRIPTION
**declaredValues** is a Set containing enum members known at compile time, allowing for clean easy iteration.
**isDeclaredValue** and its inverse **isNotDeclaredValue** allow applications to detect when they receive not yet known values from the outside and act on it with a default behavior (e.g.: log a warning to alert developers that a new version of the library containing the enum has probably been released).